### PR TITLE
Add create-release.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,31 @@
+
+CURRENT_DIR=$(shell pwd)
+DIST_DIR=${CURRENT_DIR}/dist
+
+
+.PHONY: clean
+clean:
+	rm ${DIST_DIR}/*
+
 .PHONY: lint
 lint:
 	golangci-lint run ./...
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(TARGETARCH) go build -o rollouts-plugin-trafficrouter-openshift ./
+	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -v -o ${DIST_DIR}/${BIN_NAME} .
+
+# .PHONY: gateway-api-plugin-build
+# gateway-api-plugin-build:
+# 	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -v -o ${DIST_DIR}/${BIN_NAME} .
 
 .PHONY: release
 release:
-	make BIN_NAME=gateway-api-plugin-darwin-amd64 GOOS=darwin gateway-api-plugin-build
-	make BIN_NAME=gateway-api-plugin-darwin-arm64 GOOS=darwin GOARCH=arm64 gateway-api-plugin-build
-	make BIN_NAME=gateway-api-plugin-linux-amd64 GOOS=linux gateway-api-plugin-build
-	make BIN_NAME=gateway-api-plugin-linux-arm64 GOOS=linux GOARCH=arm64 gateway-api-plugin-build
-	make BIN_NAME=gateway-api-plugin-windows-amd64.exe GOOS=windows gateway-api-plugin-build
+	make BIN_NAME=rollouts-plugin-trafficrouter-openshift-darwin-amd64 GOOS=darwin build
+	make BIN_NAME=rollouts-plugin-trafficrouter-openshift-darwin-arm64 GOOS=darwin GOARCH=arm64 build
+	make BIN_NAME=rollouts-plugin-trafficrouter-openshift-linux-amd64 GOOS=linux build
+	make BIN_NAME=rollouts-plugin-trafficrouter-openshift-linux-arm64 GOOS=linux GOARCH=arm64 build
+	make BIN_NAME=rollouts-plugin-trafficrouter-openshift-windows-amd64.exe GOOS=windows build
 
 .PHONY: test
 test: ## Run tests.

--- a/hack/create-release.sh
+++ b/hack/create-release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script creates a pre-release release based on the current commit.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+set -ex
+
+cd "$SCRIPT_DIR/.."
+make clean release
+
+cd "$SCRIPT_DIR"
+
+
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+COMMIT=`git rev-parse HEAD`
+
+if [ "$BRANCH" != "main" ]; then
+  echo "branch must be main"
+  exit 1
+fi
+
+gh release create --repo argoproj-labs/rollouts-plugin-trafficrouter-openshift -t "$COMMIT" -p "commit-$COMMIT" ../dist/rollouts-plugin-trafficrouter-openshift-* | tee


### PR DESCRIPTION
This PR:
- Creates a simple `create-release.sh` script, which builds the plugin binaries and attaches them to a new release, based on the current commit from `main` branch.