### PR TITLE
fix: use canary service name in alternate backend

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -140,7 +140,7 @@ func (r *RpcPlugin) updateRoute(ctx context.Context, routeName string, rollout *
 		slog.Info("updating alternate backend weight to " + string(desiredWeight))
 		openshiftRoute.Spec.AlternateBackends = []routev1.RouteTargetReference{{
 			Kind:   "Service",
-			Name:   routeName,
+			Name:   rollout.Spec.Strategy.Canary.CanaryService,
 			Weight: &desiredWeight,
 		}}
 	}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -127,7 +127,10 @@ var _ = Describe("Test TrafficRouter plugin for OpenShift route", func() {
 
 			// verify if the weights have been updated in the route.
 			Expect(100 - desiredWeight).To(Equal(*route.Spec.To.Weight))
+			Expect(route.Spec.AlternateBackends).Should(HaveLen(1))
+			Expect(route.Spec.AlternateBackends[0].Kind).To(Equal("Service"))
 			Expect(desiredWeight).To(Equal(*route.Spec.AlternateBackends[0].Weight))
+			Expect(route.Spec.AlternateBackends[0].Name).To(Equal(rollout.Spec.Strategy.Canary.CanaryService))
 		})
 
 		It("should return an error if the plugin config is not present", func() {


### PR DESCRIPTION
 Currently, we use the route's alternate backend to configure the canary service. However, the plugin updates the alternate backend with the route name instead of the canary service name.