### PR TITLE
Ensure when alternatebackends is empty, canary weight should be 0

### DIFF
--- a/tests/fixtures/route/route.go
+++ b/tests/fixtures/route/route.go
@@ -32,7 +32,12 @@ func HaveWeights(stableWeight, canaryWeight int32) matcher.GomegaMatcher {
 			return false
 		}
 
-		if len(route.Spec.AlternateBackends) == 1 && *route.Spec.AlternateBackends[0].Weight != canaryWeight {
+		if len(route.Spec.AlternateBackends) == 0 && canaryWeight != 0 {
+			// If alternate backend is empty, that is equivalent to a canary weight of 0, so we verify here that canary weight is 0.
+			fmt.Printf("Canary weight mismatch: got %d, want %d\n", 0, canaryWeight)
+			return false
+
+		} else if len(route.Spec.AlternateBackends) == 1 && *route.Spec.AlternateBackends[0].Weight != canaryWeight {
 			fmt.Printf("Canary weight mismatch: got %d, want %d\n", *route.Spec.AlternateBackends[0].Weight, canaryWeight)
 			return false
 		}


### PR DESCRIPTION

This PR is a fix to one of the E2E tests:
- When `.spec.alternatebackends` is empty, this means that the canary will be receiving no traffic. This is equivalent to canary weight of 0.
- In the test where we verify weights, we should ensure that when `.spec.alternateBackends` is empty, that the canary weight is 0.
- This PR adds that check to the appropriate E2E test.

We don't currently have E2E tests running as part of PRs in this repo, but I have manually run the E2E test to verify it works as expected.