### PR TITLE
Add an e2e test to verify that canary weight is reinitialized to zero

### DIFF
--- a/tests/data/route_with_weights.yaml
+++ b/tests/data/route_with_weights.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollouts-demo-stable
+spec:
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: rollouts-demo
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollouts-demo-canary
+spec:
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: rollouts-demo
+
+---
+
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: rollouts-demo
+  annotations:
+    haproxy.router.openshift.io/disable_cookies: "true"
+spec:
+  to:
+    kind: Service
+    name: rollouts-demo-stable
+    weight: 50
+  alternateBackends:
+    - kind: Service
+      name: rollouts-demo-canary
+      weight: 50
+  port:
+    targetPort: http
+  wildcardPolicy: None

--- a/tests/data/sample_rollout.yaml
+++ b/tests/data/sample_rollout.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+spec:
+  replicas: 5
+  strategy:
+    canary:
+      canaryService: rollouts-demo-canary
+      stableService: rollouts-demo-stable
+      steps:
+        - setWeight: 20
+        - pause: {}
+        - setWeight: 70
+        - pause: {}
+      trafficRouting:
+        plugins:
+          argoproj-labs/openshift:
+            routes:
+              - rollouts-demo
+            namespace: argo-rollouts-e2e
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollouts-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-demo
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: quay.io/nginx/nginx-unprivileged
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 5m


### PR DESCRIPTION
Included an e2e test that checks if the canary weight in the Route is initialized to zero once the Rollout is created.