### PR TITLE
fix: allow E2E test to wait for expected state, rather than expecting it immediately

### DIFF
--- a/tests/e2e/plugin_test.go
+++ b/tests/e2e/plugin_test.go
@@ -355,7 +355,9 @@ var _ = Describe("OpenShift Route Traffic Plugin Tests", func() {
 			By("verify if the Rollouts is Healthy and the Route is pointing to the new pods")
 			Eventually(rollout, "60s", "1s").Should(rolloutFixture.HavePhase(rolloutsv1alpha1.RolloutPhaseHealthy))
 			Eventually(route, "30s", "1s").Should(routeFixture.HaveWeights(100, 0))
-			Expect(rollout).Should(rolloutFixture.HasTransitionedToCanary(5))
+
+			By("waiting for the transition to canary, and waiting for experiment to clean up its replicaset pods")
+			Eventually(rollout, "60s", "5s").Should(rolloutFixture.HasTransitionedToCanary(5))
 
 		})
 	})

--- a/tests/fixtures/fixtures.go
+++ b/tests/fixtures/fixtures.go
@@ -91,6 +91,7 @@ func GetRouteClient() (openshiftclientset.Interface, error) {
 }
 
 func ApplyResources(path, ns string) error {
+	// #nosec G204 -- kubectl apply is intentional in e2e test fixtures; path and ns are test-controlled
 	cmd := exec.Command("kubectl", "apply", "-f", path, "-n", ns)
 	cmd.Env = os.Environ()
 	out, err := cmd.CombinedOutput()

--- a/tests/fixtures/rollout/rollout.go
+++ b/tests/fixtures/rollout/rollout.go
@@ -116,8 +116,16 @@ func HasTransitionedToCanary(expectedReplicas int) matcher.GomegaMatcher {
 			return false
 		}
 
-		if len(rsList.Items) != 2 {
-			fmt.Printf("more than 2 ReplicaSets found for the selector: %v\n", selector.String())
+		countReplicaSets := 0
+		for _, rs := range rsList.Items {
+			if rs.Spec.Replicas != nil && *rs.Spec.Replicas == 0 {
+				continue
+			}
+			countReplicaSets++
+		}
+
+		if countReplicaSets != 2 {
+			fmt.Printf("more than 2 ReplicaSets found for the selector: %v %d\n", selector.String(), countReplicaSets)
 			return false
 		}
 
@@ -135,6 +143,11 @@ func HasTransitionedToCanary(expectedReplicas int) matcher.GomegaMatcher {
 		}
 
 		for _, rs := range rsList.Items {
+
+			if rs.Spec.Replicas != nil && *rs.Spec.Replicas == 0 {
+				continue
+			}
+
 			if rs.ResourceVersion == "1" {
 				if *rs.Spec.Replicas != 0 {
 					fmt.Printf("expected the previous ReplicaSet to be scaled down: %s\n", rs.Name)


### PR DESCRIPTION
This PR:
- Allows up to 60 seconds for the Rollout to achieve the desired state, rather than just immediately expecting it to have desired state.
- Improves the `Rollout` E2E test fixture by better handling replica set count
- While E2E tests do not run as part of PRs in this repo, I have previously tested the changes work as expected.

### Test Run
```
rolloutmanager.argoproj.io/argo-rollout created
+ cd /home/jgw/workspace/argo-cd/rollouts-plugin-trafficrouter-openshift
+ make test-e2e
go test -v -p=1 -timeout=20m -race -count=1 -coverprofile=coverage.out ./tests/e2e
=== RUN   TestPlugin
Running Suite: Plugin e2e Tests Suite - /home/jgw/workspace/argo-cd/rollouts-plugin-trafficrouter-openshift/tests/e2e
=====================================================================================================================
Random Seed: 1780684989

Will run 4 of 4 specs
service/rollouts-demo-stable created
service/rollouts-demo-canary created
route.route.openshift.io/rollouts-demo created

rollout.argoproj.io/rollouts-demo created

Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
•service/rollouts-demo-stable created
service/rollouts-demo-canary created
route.route.openshift.io/rollouts-demo created
rollout.argoproj.io/rollouts-demo created

Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
W0605 14:43:52.602281 2046457 warnings.go:70] unknown field "spec.template.metadata.creationTimestamp"
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
•service/rollouts-demo-stable created
service/rollouts-demo-canary created
route.route.openshift.io/rollouts-demo-prod created
route.route.openshift.io/rollouts-demo-stage created
rollout.argoproj.io/rollouts-demo created

Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
W0605 14:44:25.686241 2046457 warnings.go:70] unknown field "spec.template.metadata.creationTimestamp"
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Healthy
•service/rollouts-demo-stable created
service/rollouts-demo-canary created
route.route.openshift.io/rollouts-demo created
analysistemplate.argoproj.io/sample-template created
rollout.argoproj.io/rollouts-demo created

Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
W0605 14:45:06.506804 2046457 warnings.go:70] unknown field "spec.template.metadata.creationTimestamp"
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Paused
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
Rollout phase mismatch, got Progressing, want Healthy
more than 2 ReplicaSets found for the selector: app=rollouts-demo 4
more than 2 ReplicaSets found for the selector: app=rollouts-demo 4
more than 2 ReplicaSets found for the selector: app=rollouts-demo 4
more than 2 ReplicaSets found for the selector: app=rollouts-demo 4
more than 2 ReplicaSets found for the selector: app=rollouts-demo 4
•

Ran 4 of 4 Specs in 158.008 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestPlugin (158.01s)
```